### PR TITLE
zsh only, zero length tollerant implementation

### DIFF
--- a/plugin.zsh
+++ b/plugin.zsh
@@ -1,9 +1,12 @@
-function add-params() {
-    BIN=$(awk '{print $1}' <<< "$BUFFER")
-    COUNT=$(wc -c <<< "$BIN")
+add-params() {
+    BIN=${BUFFER%% *}
+    COUNT=$((${#BIN}+1))
     CURSOR=$COUNT
     # hack for adding yet space before params
-    BUFFER[$CURSOR]="  "
+    if [[ $CURSOR -gt 0 ]]
+    then
+      BUFFER[$CURSOR]="  "
+    fi
 }
 
 zle -N add-params


### PR DESCRIPTION
Removed calls to unix tools and use zsh internal possibilities.
Do nothing if length is zero, which caused error messages in original implementation.
